### PR TITLE
simple-fuzzer

### DIFF
--- a/Formula/simple-fuzzer.rb
+++ b/Formula/simple-fuzzer.rb
@@ -6,7 +6,7 @@ class SimpleFuzzer < Formula
   version "0.7.1"
   head "https://github.com/orgcandman/Simple-Fuzzer.git"
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
 * Dependency 'openssl' is an alias; use the canonical name 'openssl@1.1'.